### PR TITLE
Update config.yaml to correct Huanyang spindle config

### DIFF
--- a/FluidNC/config.yaml
+++ b/FluidNC/config.yaml
@@ -206,18 +206,22 @@ coolant:
 #  spindown_ms: 0
 #  tool_num: 0
 #  speed_map: 0=0.000% 100=100.000%
- 
- # Huanyang:
- # uart:
- #   txd_pin: gpio.25
- #   rxd_pin: gpio.4
+
+ # Huanyang start config (remove this comment when adding to your config file).
+ # uart1:
+ #   txd_pin: gpio.4
+ #   rxd_pin: gpio.25
  #   rts_pin: NO_PIN
  #   baud: 9600
- #   mode: 8N1
+ #   mode: 8N
+ 
+ # Huanyang:
+ # Uart_num: 1
  # modbus_id: 1
  # tool_num: 0
  # speed_map: 0=0% 0=25% 6000=25% 24000=100%
  # off_on_alarm: false
+ # Huanyang end config (remove this comment when adding to your config file)
   
   # YL620:
   # uart:


### PR DESCRIPTION
Corrected tx pin to be 4, rx pin to be 25, (they were opposite and incorrect). Also corrected overall config adding uart1 as stand alone along with Huanyang and uart_num: 1 which was missing. Please note, the data between the comments labeled start and end is what you need for this to run on XPro V5. Lastly, I noticed that I omitted the 1 next to mode 8N, should read mode 8N1.